### PR TITLE
Disable CircleCI builds for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,13 +46,3 @@ workflows:
           filters:
             tags:
               only: /.*/
-
-      - deploy:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only: master
-


### PR DESCRIPTION
After discussion with @harterrt, I now understand that
reports-dev.telemetry.mozilla.org is currently populated from
mozilla-services/mozilla-private-reports and we need to preserve that
for now.

So, we'll turn off deploys for this repo for now and I'll be writing
up a bug to track the steps necessary to make this repo private,
copy over the mozilla-private-reports content, and eventually
retire the existing Knowledge Repo.